### PR TITLE
removed wrong check

### DIFF
--- a/lib/WebDriver/AbstractWebDriver.php
+++ b/lib/WebDriver/AbstractWebDriver.php
@@ -143,10 +143,6 @@ abstract class AbstractWebDriver
         if (preg_match('/^(get|post|delete)/', $name, $matches)) {
             $requestMethod = strtoupper($matches[0]);
             $webdriverCommand = strtolower(substr($name, strlen($requestMethod)));
-        } else if (count($arguments) > 0) {
-            $webdriverCommand = $name;
-            $this->getRequestMethod($webdriverCommand);
-            $requestMethod = 'POST';
         } else {
             $webdriverCommand = $name;
             $requestMethod = $this->getRequestMethod($webdriverCommand);


### PR DESCRIPTION
with this check in place some calls
were simply failing, cuz driver were
trying to wrongly set request method
to `POST`.

For examples in this case:
https://github.com/instaclick/php-webdriver/blob/master/lib/WebDriver/Element.php#L63
`attribute()` call surely expects
argument, but at the same time, it's
non-destructive `GET` call, not `POST`.
