### PR TITLE
Minor fix to CurlService debug output

### DIFF
--- a/lib/WebDriver/Service/CurlService.php
+++ b/lib/WebDriver/Service/CurlService.php
@@ -66,7 +66,7 @@ class CurlService implements CurlServiceInterface
 
         if ($error = curl_error($curl)) {
             $message = sprintf(
-                'Curl error thrown for http %s to %s$s',
+                'Curl error thrown for http %s to %s%s',
                 $requestMethod,
                 $url,
                 $parameters && is_array($parameters)


### PR DESCRIPTION
CurlService.php has a sprintf statement that uses $s rather than %s, leading to the last argument not being included in the output.
