### PR TITLE
Support also getValue, which is provided by Selenium

### DIFF
--- a/lib/WebDriver/Element.php
+++ b/lib/WebDriver/Element.php
@@ -31,7 +31,8 @@ namespace WebDriver;
  * @method void click() Click on an element.
  * @method void submit() Submit a FORM element.
  * @method string text() Returns the visible text for the element.
- * @method void postValue($json) Send a sequence of key strokes to an element.
+ * @method void value($json) Send a sequence of key strokes to an element.
+ * @method void getValue() Get value of input element
  * @method string name() Query for an element's tag name.
  * @method void clear() Clear a TEXTAREA or text INPUT element's value.
  * @method boolean selected() Determine if an OPTION element, or an INPUT element of type checkbox or radiobutton is currently selected.
@@ -55,7 +56,7 @@ final class Element extends Container
             'click' => array('POST'),
             'submit' => array('POST'),
             'text' => array('GET'),
-            'value' => array('POST'),
+            'value' => array('POST', 'GET'),
             'name' => array('GET'),
             'clear' => array('POST'),
             'selected' => array('GET'),


### PR DESCRIPTION
JSON wire protocol supports also GET method for reading the value

For the sake of back compatibility, the default old behaviour of `value()` is kept as POST. For explicitly invoking GET, one shall use `getValue()`
