### PR TITLE
Do not trigger error if response is empty

### DIFF
--- a/lib/WebDriver/Service/CurlService.php
+++ b/lib/WebDriver/Service/CurlService.php
@@ -83,7 +83,7 @@ class CurlService implements CurlServiceInterface
         $rawResults = trim(curl_exec($curl));
         $info = curl_getinfo($curl);
 
-        if (URLE_GOT_NOTHING !== curl_errno($curl) && $error = curl_error($curl)) {
+        if (CURLE_GOT_NOTHING !== curl_errno($curl) && $error = curl_error($curl)) {
             $message = sprintf(
                 'Curl error thrown for http %s to %s%s',
                 $requestMethod,


### PR DESCRIPTION
This happens from time to time with some
Selenium2 servers. And checking for empty
responses is Selenium2 job, not CURL anyway.
