### PR TITLE
Bugfix: Print the WebDriverException, when an element doesn't exists

### DIFF
--- a/lib/WebDriver/Container.php
+++ b/lib/WebDriver/Container.php
@@ -83,10 +83,9 @@ abstract class Container extends AbstractWebDriver
         if ($element === null) {
             throw WebDriverException::factory(WebDriverException::NO_SUCH_ELEMENT,
                 sprintf(
-                    "Element not found with %s, %s\n\n%s",
+                    "Element not found with %s, %s\n",
                     $locatorJson['using'],
-                    $locatorJson['value'],
-                    $e->getMessage()
+                    $locatorJson['value']
                 )
             );
         }


### PR DESCRIPTION
I found a bug when you grab an element which doesn't exists. For this case no try catch block around the Exception, so you can't use the $e->getMessage().

Stack Trace was:

```
Fatal error: Call to a member function getMessage() on a non-object in ...\vendor\instaclick\php-webdriver\lib\WebDriver\Container.php on line 89
```
