### PR TITLE
Window methods works only with POST method

### DIFF
--- a/lib/WebDriver/Window.php
+++ b/lib/WebDriver/Window.php
@@ -48,8 +48,8 @@ final class Window extends AbstractWebDriver
     protected function methods()
     {
         return array(
-            'size' => array('GET', 'POST'),
-            'position' => array('GET', 'POST'),
+            'size' => array('POST'),
+            'position' => array('POST'),
             'maximize' => array('POST'),
         );
     }


### PR DESCRIPTION
Today I try to resize my browser window and position it and the following exceptions were thrown:

```
The http request method called for /position is GET but it has to be POST if you want to pass the JSON parameters {"x":0,"y":0}

 The http request method called for /size is GET but it has to be POST if you want to pass the JSON parameters {"width":1280,"height":1024}
```

I removed the possibility to use GET in this methods. I use the Selenium 2 RC (2.32.0) and Firefox 20.
