### PR TITLE
Fix Sauce Connect usage.

### DIFF
--- a/lib/WebDriver/AbstractWebDriver.php
+++ b/lib/WebDriver/AbstractWebDriver.php
@@ -140,7 +140,16 @@ abstract class AbstractWebDriver
             throw WebDriverException::factory($results['status'], $message);
         }
 
-        return array('value' => $value, 'info' => $info);
+        $return = array('value' => $value, 'info' => $info);
+
+        // Pass through the sessionId return value if it exists, failing over to webdriver.remote.sessionid in the val
+        if(isset($results['sessionId'])) {
+            $return['sessionId'] = $results['sessionId'];
+        } else if(isset($value['webdriver.remote.sessionid'])) {
+            $return['sessionId']  = $value['webdriver.remote.sessionid'];
+        }
+
+        return $return;
     }
 
     /**

--- a/lib/WebDriver/WebDriver.php
+++ b/lib/WebDriver/WebDriver.php
@@ -75,8 +75,8 @@ final class WebDriver extends AbstractWebDriver
             array(CURLOPT_FOLLOWLOCATION => true)
         );
 
-        if (isset($results['value']['webdriver.remote.sessionid'])) {
-            return new Session($this->url . '/session/' . $results['value']['webdriver.remote.sessionid']);
+        if (isset($results['sessionId'])) {
+            return new Session($this->url . '/session/' . $results['sessionId']);
         }
 
         // backward compatibility fallback


### PR DESCRIPTION
Sauce Connect appears to update the sessionId value but not the webdriver.remote.sessionid value
when proxying requests from the remote selenium instance to the local proxy.  The end result is
that, without this patch, php-webdriver can start an initial sesison but guesses the wrong URL
for subsequent requests.

sessionId in the result seems a more canonical place to get the sesion ID than the
webdrive.remote.sessionid key embedded in the value, so this patch amends AbstractWebDriver to
pass that through, using webdriver.remote.sessionid as a fail-over, just in case.

The change to WebDriver.php is a simple matter of pointing to the right variable.
