### PR TITLE
Allow the option to choose the browser list to get

### DIFF
--- a/lib/WebDriver/SauceLabs/SauceRest.php
+++ b/lib/WebDriver/SauceLabs/SauceRest.php
@@ -269,9 +269,13 @@ class SauceRest
      *
      * @return array
      */
-    public function getBrowsers()
+    public function getBrowsers($browser = FALSE)
     {
-        return $this->execute('GET', 'info/browsers');
+        if($browser) {
+            return $this->execute('GET', 'info/browsers/' . $browser);
+        } else {
+            return $this->execute('GET', 'info/browsers');
+        }
     }
 
     /**


### PR DESCRIPTION
As noted here
https://saucelabs.com/docs/rest#information

> Returns an array of strings corresponding to all the browsers currently supported on Sauce Labs. (Choose the termination that defines which list you need, bearing in mind that Selenium 1 [RC] and 2 [WebDriver] are compatible with different browser/OS combinations.)
> Relative URLs: /info/browsers/all, /selenium-rc, /webdriver
