### PR TITLE
Fix adding Expect: 100-continue header with empty POST body.

### DIFF
--- a/lib/WebDriver/Service/CurlService.php
+++ b/lib/WebDriver/Service/CurlService.php
@@ -50,12 +50,7 @@ class CurlService implements CurlServiceInterface
                 break;
 
             case 'POST':
-                if ($parameters && is_array($parameters)) {
-                    curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($parameters));
-                } else {
-                    $customHeaders[] = 'Content-Length: 0';
-                }
-
+                curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($parameters));
                 curl_setopt($curl, CURLOPT_POST, true);
                 break;
 
@@ -64,12 +59,7 @@ class CurlService implements CurlServiceInterface
                 break;
 
             case 'PUT':
-                if ($parameters && is_array($parameters)) {
-                    curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($parameters));
-                } else {
-                    $customHeaders[] = 'Content-Length: 0';
-                }
-
+                curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($parameters));
                 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
                 break;
         }


### PR DESCRIPTION
If we trying to send a POST request with an empty body (like maximize window command), curl adds additional header "Expect: 100-continue". So, the result request will be like this:

```
POST /wd/hub/session/:sessionId/window/:windowId/maximize HTTP/1.1
Host: 127.0.0.1:4444
Content-Type: application/json;charset=UTF-8
Accept: application/json;charset=UTF-8
Content-Length: 0
Expect: 100-continue

```

It's not a problem for original selenium, but if we use proxy we may receive

```
HTTP/1.1 400 Bad Request
Connection: close
Content-Type: text/plain; charset=utf-8
Content-Length: 0
```

My changes will remove this header from empty request.
