### PR TITLE
Improved phpdoc for the Session::window() method

### DIFF
--- a/lib/WebDriver/Session.php
+++ b/lib/WebDriver/Session.php
@@ -228,7 +228,7 @@ final class Session extends Container
      * - $session->window($name) - set focus
      * - $session->window($window_handle)->method() - chaining
      *
-     * @return \WebDriver\AbstractWebDriver
+     * @return \WebDriver\Window|\WebDriver\Session
      */
     public function window()
     {


### PR DESCRIPTION
Documenting the 2 actual methods rather than the parent class allow IDEss to find the annotations for magic methods
