### PR TITLE
Changed the documented method to Element::value for consistency

### DIFF
--- a/lib/WebDriver/Element.php
+++ b/lib/WebDriver/Element.php
@@ -31,7 +31,7 @@ namespace WebDriver;
  * @method void click() Click on an element.
  * @method void submit() Submit a FORM element.
  * @method string text() Returns the visible text for the element.
- * @method void postValue($json) Send a sequence of key strokes to an element.
+ * @method void value($json) Send a sequence of key strokes to an element.
  * @method string name() Query for an element's tag name.
  * @method void clear() Clear a TEXTAREA or text INPUT element's value.
  * @method boolean selected() Determine if an OPTION element, or an INPUT element of type checkbox or radiobutton is currently selected.


### PR DESCRIPTION
All other annotations in the class are documenting the magic methods without the get or post prefixes.

an alternative would be to document both the method with the prefix and the shortcut, but this would have to be done on the whole library.
