### PR TITLE
Added safari as browser constant for Mac testing.

### DIFF
--- a/lib/WebDriver/Browser.php
+++ b/lib/WebDriver/Browser.php
@@ -46,4 +46,5 @@ final class Browser
     const IPHONE            = 'iPhone';
     const IPAD              = 'iPad';
     const OPERA             = 'opera';
+    const SAFARI	    = 'safari';
 }


### PR DESCRIPTION
Currently adding Safari/iOS testing on our selenium grid and discovered there is no constant defined for Safari. SafariDriver now comes bundled with selenium server since version 2.30.0 (source: https://code.google.com/p/selenium/wiki/SafariDriver)

Tested on our grid and works fine.
