### PR TITLE
Fix: make sure http errors from the requested resource are noticed

### DIFF
--- a/lib/WebDriver/Service/CurlService.php
+++ b/lib/WebDriver/Service/CurlService.php
@@ -81,6 +81,7 @@ class CurlService implements CurlServiceInterface
         }
 
         curl_setopt($curl, CURLOPT_HTTPHEADER, $customHeaders);
+        curl_setopt($curl, CURLOPT_FAILONERROR, true);
 
         $rawResult = trim(curl_exec($curl));
         $info = curl_getinfo($curl);


### PR DESCRIPTION
Note that this fix changes the default behaviour. It works for me, but I can not voice for 100% of usecases.

We might also allow the caller to pass in CURLOPT_FAILONERROR = false via extraoptions to keep some flexibility. Again, not sure who would need it.
