### PR TITLE
Always suppress "Expect: 100-continue" header

### DIFF
--- a/lib/WebDriver/Service/CurlService.php
+++ b/lib/WebDriver/Service/CurlService.php
@@ -54,8 +54,11 @@ class CurlService implements CurlServiceInterface
                     curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($parameters));
                 } else {
                     $customHeaders[] = 'Content-Length: 0';
-                    $customHeaders[] = 'Expect:';
                 }
+
+                // Suppress "Expect: 100-continue" header automatically added by cURL that
+                // causes a 1 second delay if the remote server does not support Expect.
+                $customHeaders[] = 'Expect:';
 
                 curl_setopt($curl, CURLOPT_POST, true);
                 break;
@@ -69,8 +72,11 @@ class CurlService implements CurlServiceInterface
                     curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($parameters));
                 } else {
                     $customHeaders[] = 'Content-Length: 0';
-                    $customHeaders[] = 'Expect:';
                 }
+
+                // Suppress "Expect: 100-continue" header automatically added by cURL that
+                // causes a 1 second delay if the remote server does not support Expect.
+                $customHeaders[] = 'Expect:';
 
                 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'PUT');
                 break;


### PR DESCRIPTION
cURL automatically adds an "Expect: 100-continue" header to all POST/PUT requests larger than 1 KB ([source code](https://github.com/bagder/curl/blob/576ac00eb396dd7fb2d12d0fe4b6fdeeba5071e6/lib/http.c#L2617)). It then waits for up to 1 second for a "100 Continue" response before sending the POST/PUT body ([source code](https://github.com/bagder/curl/blob/56120ca04bc6c0dc4e942504c7abf018b7ef8428/lib/transfer.c#L1973)).

The purpose of this waiting is to give the server a chance to send e.g. a 403 Forbidden, before the client sends a big payload over the wire. This concern is not relevant when talking to a WebDriver server.

The WebDriver implementation embedded in PhantomJS does not support Expect, so my Behat tests spend a lot of time waiting for these 1 second timeouts. Suppressing the Expect header makes them run about 2-3x faster (using PHP 5.3.10).

php-webdriver already suppresses the Expect header in some circumstances (see PR #41). With this PR it is always suppressed.