### PR TITLE
Adds the "deleteJob" call implementation for SauceLabs REST API

### DIFF
--- a/lib/WebDriver/SauceLabs/SauceRest.php
+++ b/lib/WebDriver/SauceLabs/SauceRest.php
@@ -59,7 +59,7 @@ class SauceRest
      * @param string $requestMethod HTTP request method
      * @param string $url           URL
      * @param mixed  $parameters    Parameters
-     * 
+     *
      * @return mixed
      *
      * @see http://saucelabs.com/docs/saucerest
@@ -224,6 +224,18 @@ class SauceRest
     public function stopJob($jobId)
     {
         return $this->execute('PUT', $this->userId . '/jobs/' . $jobId . '/stop');
+    }
+
+    /**
+     * Delete job: /rest/v1/:userId/jobs/:jobId (DELETE)
+     *
+     * @param string $jobId
+     *
+     * @return array
+     */
+    public function deleteJob($jobId)
+    {
+        return $this->execute('DELETE', $this->userId . '/jobs/' . $jobId);
     }
 
     /**


### PR DESCRIPTION
The "deleteJob" API call wasn't originally in the SauceLabs API, but they've added it over time - https://docs.saucelabs.com/reference/rest-api/#delete-job .