### PR TITLE
Consider dual-licensing Apache 2.0 or GPL-2.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,10 @@
         "browser"
     ],
     "homepage": "http://instaclick.com/",
-    "license": "Apache-2.0",
+    "license": [
+        "Apache-2.0",
+        "GPL-2.0+",
+    ],
     "authors": [
         {
             "name": "Justin Bishop",


### PR DESCRIPTION
The Apache 2.0 license is incompatible with the GPL-2.0 license.  If you are not philosophically opposed to the GPL, then dual-licensing would allow users to select the license to use with their project.

I have no immediate use-case for mixing php-webdriver with GPL-2.0-licensed code. There is no conflict with using php-webdriver to target GPL-2.0-licensed code. I merely make this suggestion as a "for the avoidance of doubt" proposal.