### PR TITLE
Fix the BC layer for the legacy execute method

### DIFF
--- a/lib/WebDriver/Session.php
+++ b/lib/WebDriver/Session.php
@@ -463,8 +463,8 @@ final class Session extends Container
     public function execute()
     {
         // execute script
-        if (func_num_args() === 0) {
-            $result = $this->curl('POST', '/execute');
+        if (func_num_args() > 0) {
+            $result = $this->curl('POST', '/execute', func_get_arg(1));
 
             return $result['value'];
         }

--- a/lib/WebDriver/Session.php
+++ b/lib/WebDriver/Session.php
@@ -455,7 +455,7 @@ final class Session extends Container
 
     /**
      * script execution method chaining, e.g.,
-     * - $session->execute() - fallback for legacy JSON Wire Protocol
+     * - $session->execute($jsonScript) - fallback for legacy JSON Wire Protocol
      * - $session->execute()->method() - chaining
      *
      * @return mixed


### PR DESCRIPTION
The legacy method gets an argument to be executed.

I discovered this while debugging https://github.com/minkphp/Mink/issues/750 (which was caused by the messed-up branch alias causing people to install the master branch when requesting the 1.x version and allowing dev versions)