### PR TITLE
preg_replace() requires quoting, specially for PHP 7.3

### DIFF
--- a/lib/WebDriver/Element.php
+++ b/lib/WebDriver/Element.php
@@ -129,6 +129,6 @@ final class Element extends Container
      */
     protected function getElementPath($elementId)
     {
-        return preg_replace(sprintf('/%s$/', $this->id), $elementId, $this->url);
+        return preg_replace(sprintf('/%s$/', preg_quote($this->id)), $elementId, $this->url);
     }
 }


### PR DESCRIPTION
Without this, a number of expressions fail (returning NULL),
leading to both non matches and warning/error:

Warning: preg_replace(): Compilation failed: number too big in {} quantifier at offset 6

This is specially noticeable under PHP 7.3, where the new PCRE2 engine
is more picky and has more features, but also may help some cases with
previous PHP versions, depending of the string being searched/replaced