### PR TITLE
Add proxy support

### DIFF
--- a/lib/WebDriver/Service/CurlService.php
+++ b/lib/WebDriver/Service/CurlService.php
@@ -87,6 +87,12 @@ class CurlService implements CurlServiceInterface
         }
 
         curl_setopt($curl, CURLOPT_HTTPHEADER, $customHeaders);
+        
+        $proxy = getenv('http_proxy');
+        if (!empty($proxy)) {
+            curl_setopt($curl, CURLOPT_PROXY, $proxy);
+            curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+        }
 
         $rawResult = trim(curl_exec($curl));
 


### PR DESCRIPTION
As Curl CLI supports http proxy via environment variable, we should add a curl opt when this variable is present.
This could be improved by adding authentication support later.