### PR TITLE
Auto init curlService on WebDriver Abstract.

### DIFF
--- a/lib/WebDriver/AbstractWebDriver.php
+++ b/lib/WebDriver/AbstractWebDriver.php
@@ -87,6 +87,7 @@ abstract class AbstractWebDriver
         $this->url = $url;
         $this->w3c = $w3c;
         $this->transientOptions = array();
+        $this->curlService = ServiceFactory::getInstance()->getService('service.curl');
     }
 
     /**
@@ -126,7 +127,7 @@ abstract class AbstractWebDriver
      */
     public function getCurlService()
     {
-        return $this->curlService ?: ServiceFactory::getInstance()->getService('service.curl');
+        return $this->curlService;
     }
 
     /**

--- a/lib/WebDriver/AbstractWebDriver.php
+++ b/lib/WebDriver/AbstractWebDriver.php
@@ -48,7 +48,7 @@ abstract class AbstractWebDriver
     /**
      * Curl service
      *
-     * @var \WebDriver\Service\CurlService
+     * @var \WebDriver\Service\CurlServiceInterface
      */
     private $curlService;
 
@@ -113,7 +113,7 @@ abstract class AbstractWebDriver
     /**
      * Set curl service
      *
-     * @param \WebDriver\Service\CurlService $curlService
+     * @param \WebDriver\Service\CurlServiceInterface $curlService
      */
     public function setCurlService($curlService)
     {
@@ -123,7 +123,7 @@ abstract class AbstractWebDriver
     /**
      * Get curl service
      *
-     * @return \WebDriver\Service\CurlService
+     * @return \WebDriver\Service\CurlServiceInterface
      */
     public function getCurlService()
     {


### PR DESCRIPTION
curlService in AbstractWebDriver should not be set manually on every instance been create (WebDriver, Session, Element),
Instead, it should be automatic initialized by get from ServiceFactory.

If user want a different curlService, they should implement `WebDriver\Service\CurlServiceInterface` and set the global default curlService by `ServiceFactory::getInstance()->setService('service.curl', $curlService);`