### PR TITLE
Fix Session::{execute, execute_async}, must use value result

### DIFF
--- a/lib/WebDriver/Session.php
+++ b/lib/WebDriver/Session.php
@@ -76,8 +76,6 @@ final class Session extends Container
             'forward' => array('POST'),
             'back' => array('POST'),
             'refresh' => array('POST'),
-            'execute' => array('POST'),
-            'execute_async' => array('POST'),
             'screenshot' => array('GET'),
             'cookie' => array('GET', 'POST'), // for DELETE, use deleteAllCookies()
             'source' => array('GET'),
@@ -433,13 +431,11 @@ final class Session extends Container
      */
     public function execute(array $jsonScript)
     {
-        if (isset($jsonScript['args'])) {
-            $jsonScript['args'] = $this->serializeArguments($jsonScript['args']);
-        }
+        $jsonScript['args'] = $this->serializeArguments($jsonScript['args']);
 
         $result = $this->curl('POST', '/execute', $jsonScript);
 
-        return $this->unserializeResult($result);
+        return $this->unserializeResult($result['value']);
     }
 
     /**
@@ -451,13 +447,11 @@ final class Session extends Container
      */
     public function execute_async(array $jsonScript)
     {
-        if (isset($jsonScript['args'])) {
-            $jsonScript['args'] = $this->serializeArguments($jsonScript['args']);
-        }
+        $jsonScript['args'] = $this->serializeArguments($jsonScript['args']);
 
         $result = $this->curl('POST', '/execute_async', $jsonScript);
 
-        return $this->unserializeResult($result);
+        return $this->unserializeResult($result['value']);
     }
 
     /**


### PR DESCRIPTION
Fix release, https://github.com/instaclick/php-webdriver/commit/8bb204d82c323fe1ccd308861045422eaa315a07 refactoring has broken the Session::{execute, execute_async} methods.

`parent::execute($jsonScript)` is equivalent to:
`$this->curl('POST', '/execute', $jsonScript)['value']`<br>not<br>`$this->curl('POST', '/execute', $jsonScript)`

tested /w https://github.com/instaclick/php-webdriver/pull/110#issuecomment-1099634396 example, ideally such example should be added to tests