### PR TITLE
Fix execute serialization compatibility with Selenium 2.x

### DIFF
--- a/lib/WebDriver/AbstractWebDriver.php
+++ b/lib/WebDriver/AbstractWebDriver.php
@@ -120,6 +120,8 @@ abstract class AbstractWebDriver
             $url .= '/' . $parameters;
         }
 
+        $this->assertNonObjectParameters($parameters);
+
         list($rawResult, $info) = ServiceFactory::getInstance()->getService('service.curl')->execute($requestMethod, $url, $parameters, $extraOptions);
 
         $httpCode = $info['http_code'];
@@ -194,6 +196,32 @@ abstract class AbstractWebDriver
             'info'       => $info,
             'sessionId'  => $sessionId,
             'sessionUrl' => $sessionId ? $this->url . '/session/' . $sessionId : $info['url'],
+        );
+    }
+
+    /**
+     * @param mixed $parameters
+     */
+    private function assertNonObjectParameters($parameters)
+    {
+        if ($parameters === null || is_scalar($parameters)) {
+            return;
+        }
+
+        if (is_array($parameters)) {
+            foreach ($parameters as $value) {
+                $this->assertNonObjectParameters($value);
+            }
+
+            return;
+        }
+
+        throw WebDriverException::factory(
+            WebDriverException::UNEXPECTED_PARAMETERS,
+            sprintf(
+                "Unable to serialize non-scalar type %s",
+                is_object($parameters) ? get_class($parameters) : gettype($parameters)
+            )
         );
     }
 

--- a/lib/WebDriver/Session.php
+++ b/lib/WebDriver/Session.php
@@ -476,7 +476,13 @@ final class Session extends Container
         foreach ($arguments as $key => $value) {
             // Potential compat-buster, i.e., W3C-specific
             if ($value instanceof Element) {
-                $arguments[$key] = [Container::WEBDRIVER_ELEMENT_ID => $value->getID()];
+                // preferably we want to detect W3C support and never set nor parse
+                // LEGACY_ELEMENT_ID, until detection is implemented, serialize to both
+                // variants, tested with Selenium v2.53.1 and v3.141.59
+                $arguments[$key] = [
+                    Container::WEBDRIVER_ELEMENT_ID => $value->getID(),
+                    Container::LEGACY_ELEMENT_ID => $value->getID(),
+                ];
                 continue;
             }
 


### PR DESCRIPTION
https://github.com/instaclick/php-webdriver/pull/110 support is not working with Selenium 2.x as it does support only the legacy key.

Selenium 3.x is supporting both exclusively but also both together. Although Selenium 2.x does not support the W3C key, it does still acept both together.

I have no environment with the new Selenium 4.x by hand, but Selenium 2.x and 3.x accept the serialized element even when there is any other key present, thus I am quite confident Selenium 4.x will support also this compatibility solution with both keys passed.

This is a bugfix, please tag a new release once merged.