### PR TITLE
Draft: Add verification of response in case of unknown command response

### DIFF
--- a/lib/WebDriver/AbstractWebDriver.php
+++ b/lib/WebDriver/AbstractWebDriver.php
@@ -184,6 +184,12 @@ abstract class AbstractWebDriver
         // According to https://w3c.github.io/webdriver/webdriver-spec.html all 4xx responses are to be considered
         // an error and return plaintext, while 5xx responses are json encoded
         if ($httpCode >= 400 && $httpCode <= 499) {
+            if (preg_match('/"error": "unknown command"/', $rawResult)) {
+                throw WebDriverException::factory(
+                    WebDriverException::UNKNOWN_COMMAND,
+                    sprintf('%s is not a valid WebDriver command. Payload ', $command, substr($rawResult, 0, 1000))
+                );
+            }
             throw WebDriverException::factory(
                 WebDriverException::CURL_EXEC,
                 'Webdriver http error: ' . $httpCode . ', payload :' . substr($rawResult, 0, 1000)


### PR DESCRIPTION
Fixes the behavior for version 4.3 of selenium-hub and node-chrome

based on my findings https://www.selenium.dev/documentation/webdriver/elements/interactions/#additional-validations, the version 4 of selenium/webdriver the `click()` doesn't required a `moveto()` call to ensure the element is in viewport.

Previous version required to have the element in view port and for that the `moveto()` was used. But in version 4 the command `moveto` is missing and `click()` behaves like 2 in 1

**Possible Replacements**
There is `moveToElement`. I tested several payloads but i always receive the: 
```json
{
    "value": {
        "error": "invalid argument",
        "message": "Unable to determine element locating strategy",
        "stacktrace": ""
    }
}
```
So this is a dead end for me atm.


**Tested with**
selenium/hub:4.3.0-20220726
selenium/node-chrome:4.3.0-20220726


**..also**
I was considering changes in the `\WebDriver\Session`, to move the method `moveto()` from `methods()` --> `obsoleteMethods()`. While this seems to be a good approach, this will introduce breaking changes and if we leave the changes only in `lib/WebDriver/AbstractWebDriver.php` is backwards compatible.


I am open to suggestions