### PR TITLE
Remove the moveto command

### DIFF
--- a/lib/WebDriver/Session.php
+++ b/lib/WebDriver/Session.php
@@ -94,7 +94,6 @@ class Session extends Container
             'execute_sql' => array('POST'),
             'keys' => array('POST'),
             'location' => array('GET', 'POST'),
-            'moveto' => array('POST'),
             'orientation' => array('GET', 'POST'),
             'window_handle' => array('GET'), // see also getWindowHandle()
             'window_handles' => array('GET'),


### PR DESCRIPTION
#118 doesn't seem to be fixed - as the command is still listed an `UnknownCommand` exception is never raised.

For example [this call in MinkSelenium2Driver](https://github.com/minkphp/MinkSelenium2Driver/blob/master/src/Selenium2Driver.php#L798) will cause something like the following error:

```
WebDriver\Exception\ScriptTimeout: Unable to execute request for an existing session: POST /session/1ddbbcdee7165bfc65954ed44175b1f1/moveto
[test:phpunit:functional] Build info: version: '4.3.0', revision: 'a4995e2c09*'
[test:phpunit:functional] System info: host: 'f998d40750df', ip: '172.21.0.5', os.name: 'Linux', os.arch: 'amd64', os.version: '5.14.0-1054-oem', java.version: '11.0.15'
[test:phpunit:functional] Driver info: driver.version: unknown
[test:phpunit:functional] 
[test:phpunit:functional] /var/www/html/vendor/instaclick/php-webdriver/lib/WebDriver/Exception.php:198
[test:phpunit:functional] /var/www/html/vendor/instaclick/php-webdriver/lib/WebDriver/AbstractWebDriver.php:174
[test:phpunit:functional] /var/www/html/vendor/instaclick/php-webdriver/lib/WebDriver/AbstractWebDriver.php:234
[test:phpunit:functional] /var/www/html/vendor/instaclick/php-webdriver/lib/WebDriver/Container.php:241
[test:phpunit:functional] /var/www/html/vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php:799
[test:phpunit:functional] /var/www/html/vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php:791
[test:phpunit:functional] /var/www/html/vendor/behat/mink/src/Element/NodeElement.php:153
[test:phpunit:functional] /var/www/html/vendor/behat/mink/src/Element/NodeElement.php:161
[test:phpunit:functional] /var/www/html/web/core/tests/Drupal/Tests/UiHelperTrait.php:100
[test:phpunit:functional] /var/www/html/web/core/tests/Drupal/Tests/UiHelperTrait.php:257
[test:phpunit:functional] /var/www/html/web/modules/custom/testmodule/tests/src/ExistingSiteJavascript/ExampleSelenium2DriverTest.php:25
[test:phpunit:functional] /var/www/html/vendor/phpunit/phpunit/src/Framework/TestResult.php:728
[test:phpunit:functional] /var/www/html/vendor/phpunit/phpunit/src/Framework/TestSuite.php:673
[test:phpunit:functional] /var/www/html/vendor/phpunit/phpunit/src/Framework/TestSuite.php:673
[test:phpunit:functional] /var/www/html/vendor/phpunit/phpunit/src/Framework/TestSuite.php:673
[test:phpunit:functional] /var/www/html/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:661
[test:phpunit:functional] /var/www/html/vendor/phpunit/phpunit/src/TextUI/Command.php:144
[test:phpunit:functional] /var/www/html/vendor/phpunit/phpunit/src/TextUI/Command.php:97

```