### PR TITLE
Update the way to click an element

### DIFF
--- a/lib/WebDriver/Element.php
+++ b/lib/WebDriver/Element.php
@@ -148,4 +148,13 @@ class Element extends Container
     {
         return preg_replace('/' . preg_quote($this->id) . '$/', $identifier, $this->url);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function click()
+    {
+        return parent::click([':id' => $this->id]);
+    }
+
 }


### PR DESCRIPTION
## Problem description

When the click method is executed on a checkbox in Selenium 4.8.0, the following error appears:

`non-positive contentLength: 0 `

## Steps to reproduce

Call Webdriver\Element::click method on a  checkbox with this library, using Selenium 4.8.0.

## Solution

Send the :id attribute in the POST request. This solution is based in how this is done at [php-webdriver/webdriver](https://github.com/php-webdriver/php-webdriver/blob/main/lib/Remote/RemoteWebElement.php#L79)