### PR TITLE
fix: catch ScriptTimeout exception into a variable

### DIFF
--- a/lib/WebDriver/Session.php
+++ b/lib/WebDriver/Session.php
@@ -48,7 +48,6 @@ use WebDriver\Exception as WebDriverException;
  * @method void postAlert_text($jsonText) Sends keystrokes to a JavaScript prompt() dialog.
  * @method void accept_alert() Accepts the currently displayed alert dialog.
  * @method void dismiss_alert() Dismisses the currently displayed alert dialog.
- * @method void moveto($jsonCoordinates) Move the mouse by an offset of the specified element (or current mouse cursor).
  * @method void click($jsonButton) Click any mouse button (at the coordinates set by the last moveto command).
  * @method void buttondown() Click and hold the left mouse button (at the coordinates set by the last moveto command).
  * @method void buttonup() Releases the mouse button previously held (where the mouse is currently at).
@@ -305,7 +304,7 @@ final class Session extends Container
     {
         try {
             $result = $this->curl('POST', '/moveto', $parameters);
-        } catch (WebDriverException\ScriptTimeout) {
+        } catch (WebDriverException\ScriptTimeout $e) {
             throw WebDriverException::factory(WebDriverException::UNKNOWN_ERROR);
         }
 


### PR DESCRIPTION
Fixes #127 

My Behat UI tests pass with these changes. See the issue for details of the problem.

My IDE also notices the problem and tells me:
Catching exceptions without capturing them to variables is only possible since PHP 8.0

So the code released in 1.4.17 will work on PHP 8 but not on PHP 7. I am running tests with PHP 7.4