### PR TITLE
Load Mink Selenium 2 Driver package from source to have tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,12 @@ jobs:
       - name: Install dependencies
         run: |
           composer config version 1.4.99
+          composer config preferred-install.behat/mink-selenium2-driver source
+          composer config preferred-install.* dist         
           composer require --no-update behat/mink-selenium2-driver:dev-master --dev --quiet
           composer require --no-update mink/driver-testsuite:dev-master --dev --quiet
           php -r '$json = json_decode(file_get_contents ("composer.json"), true); $json["autoload"]["psr-4"]["Behat\\Mink\\Tests\\Driver\\"] = "vendor/behat/mink-selenium2-driver/tests/"; file_put_contents("composer.json", json_encode($json, JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT));'
-          composer update --no-interaction --prefer-dist
+          composer update --no-interaction
 
       - name: Start Selenium & Mink test server
         run: |


### PR DESCRIPTION
The MinkSelenium2Driver project has added its `tests` folder and `phpunit.xml.dist` file into `.gitattributes` and therefore they haven't downloaded anymore when using the `--dist` option of Composer.

I've updated Composer config so that it will use `--prefer-dist` for all packages, except the `behat/mink-selenium2-driver`.