### PR TITLE
Allow getting window handle in W3C mode

### DIFF
--- a/lib/WebDriver/Window.php
+++ b/lib/WebDriver/Window.php
@@ -83,9 +83,9 @@ class Window extends AbstractWebDriver
     public function getHandle()
     {
         if (! $this->windowHandle) {
-            $result = $this->curl('GET', $this->url);
+            $result = $this->curl('GET', '');
 
-            $this->windowHandle = array_key_exists(self::WEB_WINDOW_ID, $result['value'])
+            $this->windowHandle = is_array($result['value']) && array_key_exists(self::WEB_WINDOW_ID, $result['value'])
                 ? $result['value'][self::WEB_WINDOW_ID]
                 : $result['value'];
         }


### PR DESCRIPTION
The `$session->window()->handle();` code had several issues:

1. the URL queried for the window handle was `/session/{session id}/windowsession/{session id}/window`
2. there was a PHP Notice, where a returned window handle (for me it was always a string) was treated as an array

Both issues are addressed in this PR.