### PR TITLE
Fix the upload tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,4 @@ jobs:
         env:
           SELENIUM_VERSION: ${{ matrix.selenium }}
           WEB_FIXTURES_BROWSER: firefox
+          TEST_MACHINE_BASE_PATH: ${{ github.workspace }}/vendor/mink/driver-testsuite/web-fixtures/


### PR DESCRIPTION
The default value of `TEST_MACHINE_BASE_PATH` expects to find the `mink/driver-testsuite` in the vendor folder of the selenium2-driver package. As the CI installs both packages side by side, it needs to configure it explicitly.

Follow-up of #144 which was merged before I had a chance to look at failing tests.