### PR TITLE
Fix the setup for uploads in the CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Start Selenium & Mink test server
         run: |
           mkdir logs
-          docker run --net host --name selenium --volume /dev/shm:/dev/shm --shm-size 2g "selenium/standalone-firefox:${{ matrix.selenium }}" &> logs/selenium.log &
+          docker run --net host --name selenium --volume /dev/shm:/dev/shm --volume ./vendor/mink/driver-testsuite/web-fixtures:/fixtures --shm-size 2g "selenium/standalone-firefox:${{ matrix.selenium }}" &> logs/selenium.log &
           vendor/bin/mink-test-server &> logs/mink-test-server.log &
           while ! nc -z localhost 4444 </dev/null; do echo Waiting for remote driver to start...; sleep 1; done
           while ! nc -z localhost 8002 </dev/null; do echo Waiting for PHP server to start...; sleep 1; done
@@ -56,3 +56,4 @@ jobs:
           SELENIUM_VERSION: ${{ matrix.selenium }}
           WEB_FIXTURES_BROWSER: firefox
           TEST_MACHINE_BASE_PATH: ${{ github.workspace }}/vendor/mink/driver-testsuite/web-fixtures/
+          DRIVER_MACHINE_BASE_PATH: /fixtures/


### PR DESCRIPTION
Older selenium versions support a non-standard feature to upload a file to the runner, which is used by the Mink driver when available. Newer Selenium versions implementing the W3C protocol don't support this anymore. Attaching a file to a file input requires using a file path that already exists on the runner. this configures the Mink testsuite to properly share the fixtures with the docker image of the runner.